### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![forbid(unsafe_code)]
 
 #[cfg(not(feature = "std"))]
 extern crate core as std;


### PR DESCRIPTION
Add `#![forbid(unsafe_code)]` directive to crate root. This makes the compiler verify that there is indeed no unsafe code in the crate, which aids analysis and makes output of tools such as `cargo geiger` more reliable.