### PR TITLE
Adapt lib.rs doc test for endianness-dependent hash result

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,14 @@ use std::io::{self, BufRead};
 /// let data = Data { byte: 0x1F, word: 0xABCD, big: !0 };
 /// data.hash(&mut adler);
 ///
-/// assert_eq!(adler.checksum(), 0x33410990);
+/// // hash value depends on architecture endianness
+/// if cfg!(target_endian = "little") {
+///     assert_eq!(adler.checksum(), 0x33410990);
+/// }
+/// if cfg!(target_endian = "big") {
+///     assert_eq!(adler.checksum(), 0x331F0990);
+/// }
+///
 /// ```
 ///
 /// [`new`]: #method.new


### PR DESCRIPTION
The exact in-memory byte representation of the u64 field of the example `Data` struct are dependent on architecture endianness.

This PR converts the doc test that's "broken" on big-endian architectures (e.g. s390x / System Z) to specific assertions gated by the `target_endian` `cfg` attribute.

Fixes #8 